### PR TITLE
Update Rss2Parser.java

### DIFF
--- a/pkrss/src/main/java/com/pkmmte/pkrss/parser/Rss2Parser.java
+++ b/pkrss/src/main/java/com/pkmmte/pkrss/parser/Rss2Parser.java
@@ -78,7 +78,7 @@ public class Rss2Parser extends Parser {
 							article.setId(Math.abs(article.hashCode()));
 
 							// Remove content thumbnail
-							if(article.getImage() != null)
+							if(article.getImage() != null && article.getContent() != null)
 								article.setContent(article.getContent().replaceFirst("<img.+?>", ""));
 
 							// (Optional) Log article contents... without the actual content


### PR DESCRIPTION
Prevent NullPointerException caused by attempting to strip <img> tag from null content.

Example feed which caused an issue: http://feeds.bbci.co.uk/news/rss.xml
