### PR TITLE
DateFormat must parse date in US locale

### DIFF
--- a/pkrss/src/main/java/com/pkmmte/pkrss/parser/AtomParser.java
+++ b/pkrss/src/main/java/com/pkmmte/pkrss/parser/AtomParser.java
@@ -34,7 +34,7 @@ public class AtomParser extends Parser {
 
 	public AtomParser() {
 		// Initialize DateFormat object with the default date formatting
-		dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault());
+		dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
 		dateFormat.setTimeZone(Calendar.getInstance().getTimeZone());
 		pattern = Pattern.compile("-\\d{1,4}x\\d{1,4}");
 

--- a/pkrss/src/main/java/com/pkmmte/pkrss/parser/Rss2Parser.java
+++ b/pkrss/src/main/java/com/pkmmte/pkrss/parser/Rss2Parser.java
@@ -36,7 +36,7 @@ public class Rss2Parser extends Parser {
 
 	public Rss2Parser() {
 		// Initialize DateFormat object with the default date formatting
-		dateFormat = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z", Locale.getDefault());
+		dateFormat = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z", Locale.US);
 		dateFormat.setTimeZone(Calendar.getInstance().getTimeZone());
 		pattern = Pattern.compile("-\\d{1,4}x\\d{1,4}");
 


### PR DESCRIPTION
If mobile device have default language set something other than English, method parseObject on DataFormat throws ParseException.